### PR TITLE
Redirect security reports to github mechanism (rather than discourse)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ released tagged minor version. All previous versions are unsupported.
 
 ## Reporting a Vulnerability
 
-Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discuss.dockstore.org](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 
+Go to [Security](https://github.com/dockstore/dockstore/security) to report a vulnerability or if you are already there, use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discuss.dockstore.org](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ released tagged minor version. All previous versions are unsupported.
 
 ## Reporting a Vulnerability
 
-Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discourse](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 
+Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discuss.dockstore.org](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,15 +7,4 @@ released tagged minor version. All previous versions are unsupported.
 
 ## Reporting a Vulnerability
 
-Users are able to open helpdesk tickets on [Discourse](https://discuss.dockstore.org/). Users can create helpdesk tickets in case of privacy complaints, security vulnerabilities, or any other urgent matter related to Dockstore. Helpdesk tickets will be addressed by Dockstore administrators.
-
-The following steps can be taken to create a helpdesk ticket (also shown [here](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506)).
-
-1. Navigate to [Discourse](https://discuss.dockstore.org/) and login.
-2. Select your profile icon, located in the top right corner of the screen.
-3. Select the `mail` icon, located in the dropdown.
-4. Send a message to the `dockstore_admins` group.
-
-Note
-
-> If you are unable to see a New Message button on the mail page, you may be considered a new user and have insufficient privileges. Entering 5 topics and viewing 30 posts over a minimum of 10 minutes will raise your privileges. You will be notified of any privilege changes to your account via the mailbox.
+Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discourse](https://discuss.dockstore.org/) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,6 @@ released tagged minor version. All previous versions are unsupported.
 
 ## Reporting a Vulnerability
 
-Go to [Security](https://github.com/dockstore/dockstore/security) to report a vulnerability or if you are already there, use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discuss.dockstore.org](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 
+Go to [Security](https://github.com/dockstore/dockstore/security) to report a vulnerability or if you are already there, use the "Report a vulnerability" button to the upper right to report security vulnerabilities. For faster processing, please add the `Dockstore/Dockstore` team as collaborators on the report. 
+
+A helpdesk ticket on [discuss.dockstore.org](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ released tagged minor version. All previous versions are unsupported.
 
 ## Reporting a Vulnerability
 
-Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discourse](https://discuss.dockstore.org/) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 
+Use the "Report a vulnerability" button to the upper right to report security vulnerabilities. A helpdesk ticket on [discourse](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506) may be an option for privacy complaints or other urgent non-security matters. Both options will be addressed by Dockstore administrators. 


### PR DESCRIPTION
Redirecting policy as a part of https://ucsc-cgl.atlassian.net/browse/SEAB-4291